### PR TITLE
check path exists before comparing

### DIFF
--- a/zray.php
+++ b/zray.php
@@ -125,6 +125,9 @@ class Wordpress {
 				$found=false;
 				$pluginsTime+=$time;
 				foreach($this->plugins as $key => $plugin){
+					if(!isset($plugin['path'])){
+						continue;
+					}
 					if(strpos($plugin['path'] . DIRECTORY_SEPARATOR,$name)!==false){
 						$this->plugins[$key]['loadtime']=$time;
 						$found=true;


### PR DESCRIPTION
Hi,

Installed a fresh copy of Zend Server 8 on Windows 7 and started working on a WordPress project which uses Bedrock (https://roots.io/bedrock/) for a Composer friendly WordPress environment.

Started getting a lot of notices saying:

`Notice: Undefined index: path in C:\Program Files (x86)\Zend\ZendServer\data\zray\extensions\Wordpress\zray.php on line 128`

Looked through the zray.php class, and I can't see how this isn't set before plugins property is used?
